### PR TITLE
Cделать сохранение idempotency-ключей и состояний обработки

### DIFF
--- a/core-service/src/main/java/ru/itmo/idempotency/core/service/IdempotencySearchService.java
+++ b/core-service/src/main/java/ru/itmo/idempotency/core/service/IdempotencySearchService.java
@@ -1,0 +1,41 @@
+package ru.itmo.idempotency.core.service;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ru.itmo.idempotency.core.domain.IdempotencyEntity;
+import ru.itmo.idempotency.core.domain.IdempotencyStatus;
+import ru.itmo.idempotency.core.repository.IdempotencyRepository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class IdempotencySearchService {
+
+    private final IdempotencyRepository idempotencyRepository;
+
+    @Transactional
+    public Optional<IdempotencyEntity> acquireFirstNotLocked(IdempotencyStatus status) {
+        return idempotencyRepository.lockFirstByStatus(status.name());
+    }
+
+    @Transactional
+    public Optional<IdempotencyEntity> acquireUniqueWaitIfLocked(String globalKey) {
+        return idempotencyRepository.findByGlobalKeyForUpdate(globalKey);
+    }
+
+    @Transactional(readOnly = true)
+    public List<IdempotencyEntity> findCommittedBatchForCleanup(OffsetDateTime threshold, int batchSize) {
+        return idempotencyRepository.findByStatusAndUpdateDateBefore(
+                IdempotencyStatus.COMMITTED,
+                threshold,
+                PageRequest.of(0, batchSize, Sort.by("updateDate").ascending())
+        );
+    }
+}

--- a/core-service/src/main/java/ru/itmo/idempotency/core/service/IdempotencyService.java
+++ b/core-service/src/main/java/ru/itmo/idempotency/core/service/IdempotencyService.java
@@ -1,0 +1,57 @@
+package ru.itmo.idempotency.core.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ru.itmo.idempotency.common.config.RouteModels;
+import ru.itmo.idempotency.core.domain.IdempotencyEntity;
+import ru.itmo.idempotency.core.domain.IdempotencyStatus;
+import ru.itmo.idempotency.core.repository.IdempotencyRepository;
+
+import java.util.Collection;
+
+@Service
+@RequiredArgsConstructor
+public class IdempotencyService {
+
+    private final IdempotencyRepository idempotencyRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public IdempotencyEntity save(String globalKey,
+                                  String sourceUid,
+                                  RouteModels.RouteSnapshot snapshot,
+                                  JsonNode headers,
+                                  JsonNode payload) {
+        IdempotencyEntity entity = IdempotencyEntity.builder()
+                .globalKey(globalKey)
+                .sourceUid(sourceUid)
+                .serviceName(snapshot.service())
+                .integrationName(snapshot.integration())
+                .yamlSnapshot(objectMapper.valueToTree(snapshot))
+                .headers(headers)
+                .payload(payload)
+                .status(IdempotencyStatus.RESERVED)
+                .build();
+        return idempotencyRepository.saveAndFlush(entity);
+    }
+
+    @Transactional
+    public IdempotencyEntity changeStatus(IdempotencyEntity entity, IdempotencyStatus status, String description) {
+        entity.setStatus(status);
+        entity.setStatusDescription(DescriptionUtils.limit(description));
+        return idempotencyRepository.save(entity);
+    }
+
+    @Transactional
+    public IdempotencyEntity markAsError(IdempotencyEntity entity, String description) {
+        return changeStatus(entity, IdempotencyStatus.ERROR, description);
+    }
+
+    @Transactional
+    public void delete(Collection<IdempotencyEntity> entities) {
+        idempotencyRepository.deleteAllInBatch(entities);
+    }
+}

--- a/core-service/src/main/resources/db/migration/V1__init.sql
+++ b/core-service/src/main/resources/db/migration/V1__init.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS idempotency (
-                                           global_key VARCHAR(512) PRIMARY KEY,
+    global_key VARCHAR(512) PRIMARY KEY,
     source_uid VARCHAR(255) NOT NULL,
     service_name VARCHAR(255) NOT NULL,
     integration_name VARCHAR(255) NOT NULL,
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS idempotency (
     status_description VARCHAR(255),
     create_date TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     update_date TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
-    );
+);
 
 CREATE INDEX IF NOT EXISTS idx_idempotency_status_create_date
     ON idempotency (status, create_date);
@@ -19,8 +19,8 @@ CREATE INDEX IF NOT EXISTS idx_idempotency_status_update_date
     ON idempotency (status, update_date);
 
 CREATE TABLE IF NOT EXISTS kafka_event_outbox (
-                                                  id BIGSERIAL PRIMARY KEY,
-                                                  global_key VARCHAR(512),
+    id BIGSERIAL PRIMARY KEY,
+    global_key VARCHAR(512),
     service_name VARCHAR(255),
     integration_name VARCHAR(255),
     yaml_snapshot JSONB NOT NULL,
@@ -30,14 +30,14 @@ CREATE TABLE IF NOT EXISTS kafka_event_outbox (
     result_description VARCHAR(255),
     create_date TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     update_date TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
-    );
+);
 
 CREATE INDEX IF NOT EXISTS idx_kafka_event_outbox_status_create_date
     ON kafka_event_outbox (status, create_date);
 
 CREATE TABLE IF NOT EXISTS event_audit (
-                                           id BIGSERIAL PRIMARY KEY,
-                                           global_key VARCHAR(512),
+    id BIGSERIAL PRIMARY KEY,
+    global_key VARCHAR(512),
     service_name VARCHAR(255),
     integration_name VARCHAR(255),
     reason VARCHAR(255) NOT NULL,
@@ -45,7 +45,7 @@ CREATE TABLE IF NOT EXISTS event_audit (
     payload JSONB,
     yaml_snapshot JSONB,
     create_date TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
-    );
+);
 
 CREATE INDEX IF NOT EXISTS idx_event_audit_create_date
     ON event_audit (create_date);


### PR DESCRIPTION
- Сделать сохранение idempotency-ключей и состояний обработки
- Добавить поиск и блокировки, чтобы одинаковые запросы не пролезали одновременно
- Закрыть базовый сценарий с гонками на одном ключе