### PR TITLE
issue 43 Core: расширить схему хранения retry и lease-based claiming

### DIFF
--- a/core-service/src/main/java/ru/itmo/idempotency/core/domain/IdempotencyEntity.java
+++ b/core-service/src/main/java/ru/itmo/idempotency/core/domain/IdempotencyEntity.java
@@ -6,15 +6,20 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PostPersist;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.springframework.data.domain.Persistable;
 import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
@@ -27,7 +32,7 @@ import java.time.ZoneOffset;
 @AllArgsConstructor
 @Entity
 @Table(name = "idempotency")
-public class IdempotencyEntity {
+public class IdempotencyEntity implements Persistable<String> {
 
     @Id
     @Column(name = "global_key", nullable = false, length = 512)
@@ -61,15 +66,46 @@ public class IdempotencyEntity {
     @Column(name = "status_description", length = 255)
     private String statusDescription;
 
+    @Column(name = "retry_count", nullable = false)
+    private Integer retryCount;
+
+    @Column(name = "next_attempt_date", nullable = false)
+    private OffsetDateTime nextAttemptDate;
+
+    @Column(name = "owner_id", length = 128)
+    private String ownerId;
+
+    @Column(name = "lease_until")
+    private OffsetDateTime leaseUntil;
+
+    @Column(name = "last_claim_date")
+    private OffsetDateTime lastClaimDate;
+
     @Column(name = "create_date", nullable = false)
     private OffsetDateTime createDate;
 
     @Column(name = "update_date", nullable = false)
     private OffsetDateTime updateDate;
 
+    @Transient
+    @Default
+    private boolean newEntity = true;
+
+    @Override
+    public String getId() {
+        return globalKey;
+    }
+
+    @Override
+    public boolean isNew() {
+        return newEntity;
+    }
+
     @PrePersist
     void prePersist() {
         OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        retryCount = retryCount == null ? 0 : retryCount;
+        nextAttemptDate = nextAttemptDate == null ? now : nextAttemptDate;
         createDate = createDate == null ? now : createDate;
         updateDate = updateDate == null ? now : updateDate;
     }
@@ -77,5 +113,11 @@ public class IdempotencyEntity {
     @PreUpdate
     void preUpdate() {
         updateDate = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+
+    @PostPersist
+    @PostLoad
+    void markNotNew() {
+        newEntity = false;
     }
 }

--- a/core-service/src/main/java/ru/itmo/idempotency/core/domain/KafkaEventOutboxEntity.java
+++ b/core-service/src/main/java/ru/itmo/idempotency/core/domain/KafkaEventOutboxEntity.java
@@ -62,6 +62,21 @@ public class KafkaEventOutboxEntity {
     @Column(name = "result_description", length = 255)
     private String resultDescription;
 
+    @Column(name = "retry_count", nullable = false)
+    private Integer retryCount;
+
+    @Column(name = "next_attempt_date", nullable = false)
+    private OffsetDateTime nextAttemptDate;
+
+    @Column(name = "owner_id", length = 128)
+    private String ownerId;
+
+    @Column(name = "lease_until")
+    private OffsetDateTime leaseUntil;
+
+    @Column(name = "last_claim_date")
+    private OffsetDateTime lastClaimDate;
+
     @Column(name = "create_date", nullable = false)
     private OffsetDateTime createDate;
 
@@ -71,6 +86,8 @@ public class KafkaEventOutboxEntity {
     @PrePersist
     void prePersist() {
         OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        retryCount = retryCount == null ? 0 : retryCount;
+        nextAttemptDate = nextAttemptDate == null ? now : nextAttemptDate;
         createDate = createDate == null ? now : createDate;
         updateDate = updateDate == null ? now : updateDate;
     }

--- a/core-service/src/main/java/ru/itmo/idempotency/core/repository/IdempotencyRepository.java
+++ b/core-service/src/main/java/ru/itmo/idempotency/core/repository/IdempotencyRepository.java
@@ -20,17 +20,37 @@ public interface IdempotencyRepository extends JpaRepository<IdempotencyEntity, 
             SELECT *
             FROM idempotency
             WHERE status = :status
-            ORDER BY create_date
+              AND next_attempt_date <= CURRENT_TIMESTAMP
+              AND (lease_until IS NULL OR lease_until < CURRENT_TIMESTAMP)
+            ORDER BY next_attempt_date, create_date
             LIMIT 1
             FOR UPDATE SKIP LOCKED
             """, nativeQuery = true)
-    Optional<IdempotencyEntity> lockFirstByStatus(@Param("status") String status);
+    Optional<IdempotencyEntity> lockFirstAvailableByStatus(@Param("status") String status);
+
+    @Query(value = """
+            SELECT *
+            FROM idempotency
+            WHERE status = :status
+              AND update_date <= :threshold
+              AND (lease_until IS NULL OR lease_until < CURRENT_TIMESTAMP)
+            ORDER BY update_date
+            LIMIT 1
+            FOR UPDATE SKIP LOCKED
+            """, nativeQuery = true)
+    Optional<IdempotencyEntity> lockFirstByStatusAndUpdateDateBefore(@Param("status") String status,
+                                                                     @Param("threshold") OffsetDateTime threshold);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select entity from IdempotencyEntity entity where entity.globalKey = :globalKey")
     Optional<IdempotencyEntity> findByGlobalKeyForUpdate(@Param("globalKey") String globalKey);
 
     Page<IdempotencyEntity> findByStatus(IdempotencyStatus status, Pageable pageable);
+
+    long countByStatus(IdempotencyStatus status);
+
+    @Query("select count(entity) from IdempotencyEntity entity where entity.ownerId is not null and entity.leaseUntil < :threshold")
+    long countExpiredLeases(@Param("threshold") OffsetDateTime threshold);
 
     List<IdempotencyEntity> findByStatusAndUpdateDateBefore(IdempotencyStatus status,
                                                             OffsetDateTime updateDate,

--- a/core-service/src/main/java/ru/itmo/idempotency/core/repository/KafkaEventOutboxRepository.java
+++ b/core-service/src/main/java/ru/itmo/idempotency/core/repository/KafkaEventOutboxRepository.java
@@ -1,9 +1,14 @@
 package ru.itmo.idempotency.core.repository;
 
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import ru.itmo.idempotency.core.domain.KafkaEventOutboxEntity;
+import ru.itmo.idempotency.core.domain.OutboxStatus;
+
+import java.time.OffsetDateTime;
 
 import java.util.Optional;
 
@@ -13,9 +18,20 @@ public interface KafkaEventOutboxRepository extends JpaRepository<KafkaEventOutb
             SELECT *
             FROM kafka_event_outbox
             WHERE status = :status
-            ORDER BY create_date
+              AND next_attempt_date <= CURRENT_TIMESTAMP
+              AND (lease_until IS NULL OR lease_until < CURRENT_TIMESTAMP)
+            ORDER BY next_attempt_date, create_date
             LIMIT 1
             FOR UPDATE SKIP LOCKED
             """, nativeQuery = true)
-    Optional<KafkaEventOutboxEntity> lockFirstByStatus(@Param("status") String status);
+    Optional<KafkaEventOutboxEntity> lockFirstAvailableByStatus(@Param("status") String status);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select entity from KafkaEventOutboxEntity entity where entity.id = :id")
+    Optional<KafkaEventOutboxEntity> findByIdForUpdate(@Param("id") Long id);
+
+    long countByStatus(OutboxStatus status);
+
+    @Query("select count(entity) from KafkaEventOutboxEntity entity where entity.ownerId is not null and entity.leaseUntil < :threshold")
+    long countExpiredLeases(@Param("threshold") OffsetDateTime threshold);
 }

--- a/core-service/src/main/java/ru/itmo/idempotency/core/service/IdempotencySearchService.java
+++ b/core-service/src/main/java/ru/itmo/idempotency/core/service/IdempotencySearchService.java
@@ -21,13 +21,16 @@ public class IdempotencySearchService {
     private final IdempotencyRepository idempotencyRepository;
 
     @Transactional
-    public Optional<IdempotencyEntity> acquireFirstNotLocked(IdempotencyStatus status) {
-        return idempotencyRepository.lockFirstByStatus(status.name());
+    public Optional<IdempotencyEntity> acquireUniqueWaitIfLocked(String globalKey) {
+        return idempotencyRepository.findByGlobalKeyForUpdate(globalKey);
     }
 
     @Transactional
-    public Optional<IdempotencyEntity> acquireUniqueWaitIfLocked(String globalKey) {
-        return idempotencyRepository.findByGlobalKeyForUpdate(globalKey);
+    public Optional<IdempotencyEntity> acquireFirstTimedOutReply(OffsetDateTime threshold) {
+        return idempotencyRepository.lockFirstByStatusAndUpdateDateBefore(
+                IdempotencyStatus.WAITING_ASYNC_RESPONSE.name(),
+                threshold
+        );
     }
 
     @Transactional(readOnly = true)

--- a/core-service/src/main/java/ru/itmo/idempotency/core/service/IdempotencyService.java
+++ b/core-service/src/main/java/ru/itmo/idempotency/core/service/IdempotencyService.java
@@ -11,9 +11,11 @@ import ru.itmo.idempotency.core.domain.IdempotencyEntity;
 import ru.itmo.idempotency.core.domain.IdempotencyStatus;
 import ru.itmo.idempotency.core.repository.IdempotencyRepository;
 
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Collection;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,9 +30,6 @@ public class IdempotencyService {
                                   RouteModels.RouteSnapshot snapshot,
                                   JsonNode headers,
                                   JsonNode payload) {
-        if (idempotencyRepository.existsById(globalKey)) {
-            throw new DataIntegrityViolationException("Duplicate globalKey: " + globalKey);
-        }
         OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
         IdempotencyEntity entity = IdempotencyEntity.builder()
                 .globalKey(globalKey)
@@ -41,16 +40,21 @@ public class IdempotencyService {
                 .headers(headers)
                 .payload(payload)
                 .status(IdempotencyStatus.RESERVED)
-                .createDate(now)
-                .updateDate(now)
+                .retryCount(0)
+                .nextAttemptDate(now)
                 .build();
         return idempotencyRepository.saveAndFlush(entity);
     }
 
     @Transactional
+    public Optional<IdempotencyEntity> claimNextReserved(String ownerId, Duration leaseDuration) {
+        return idempotencyRepository.lockFirstAvailableByStatus(IdempotencyStatus.RESERVED.name())
+                .map(entity -> claim(entity, ownerId, leaseDuration));
+    }
+
+    @Transactional
     public IdempotencyEntity changeStatus(IdempotencyEntity entity, IdempotencyStatus status, String description) {
-        entity.setStatus(status);
-        entity.setStatusDescription(DescriptionUtils.limit(description));
+        applyStatus(entity, status, description);
         return idempotencyRepository.save(entity);
     }
 
@@ -60,7 +64,111 @@ public class IdempotencyService {
     }
 
     @Transactional
+    public IdempotencyEntity scheduleRetry(IdempotencyEntity entity,
+                                           String description,
+                                           Duration delay,
+                                           int maxAttempts) {
+        applyRetry(entity, description, delay, maxAttempts);
+        return idempotencyRepository.save(entity);
+    }
+
+    @Transactional
+    public boolean completeClaimedDelivery(String globalKey,
+                                           String ownerId,
+                                           IdempotencyStatus status,
+                                           String description) {
+        return updateClaimed(globalKey, ownerId, entity -> applyStatus(entity, status, description));
+    }
+
+    @Transactional
+    public boolean retryClaimedDelivery(String globalKey,
+                                        String ownerId,
+                                        String description,
+                                        Duration delay,
+                                        int maxAttempts) {
+        return updateClaimed(globalKey, ownerId, entity -> applyRetry(entity, description, delay, maxAttempts));
+    }
+
+    @Transactional
+    public boolean failClaimedDelivery(String globalKey, String ownerId, String description) {
+        return updateClaimed(globalKey, ownerId, entity -> applyStatus(entity, IdempotencyStatus.ERROR, description));
+    }
+
+    @Transactional
+    public IdempotencyEntity restart(IdempotencyEntity entity) {
+        applyRestart(entity);
+        return idempotencyRepository.save(entity);
+    }
+
+    @Transactional
     public void delete(Collection<IdempotencyEntity> entities) {
         idempotencyRepository.deleteAllInBatch(entities);
+    }
+
+    private IdempotencyEntity claim(IdempotencyEntity entity, String ownerId, Duration leaseDuration) {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        entity.setOwnerId(ownerId);
+        entity.setLeaseUntil(now.plus(leaseDuration));
+        entity.setLastClaimDate(now);
+        return idempotencyRepository.save(entity);
+    }
+
+    private boolean updateClaimed(String globalKey,
+                                  String ownerId,
+                                  java.util.function.Consumer<IdempotencyEntity> updater) {
+        IdempotencyEntity entity = idempotencyRepository.findByGlobalKeyForUpdate(globalKey).orElse(null);
+        if (entity == null || entity.getOwnerId() == null || !entity.getOwnerId().equals(ownerId)) {
+            return false;
+        }
+
+        updater.accept(entity);
+        idempotencyRepository.save(entity);
+        return true;
+    }
+
+    private void applyStatus(IdempotencyEntity entity, IdempotencyStatus status, String description) {
+        entity.setStatus(status);
+        entity.setStatusDescription(DescriptionUtils.limit(description));
+        entity.setNextAttemptDate(OffsetDateTime.now(ZoneOffset.UTC));
+        clearLease(entity);
+    }
+
+    private void applyRetry(IdempotencyEntity entity,
+                            String description,
+                            Duration delay,
+                            int maxAttempts) {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        int nextRetryCount = entity.getRetryCount() + 1;
+        entity.setRetryCount(nextRetryCount);
+        if (nextRetryCount >= maxAttempts) {
+            entity.setStatus(IdempotencyStatus.ERROR);
+            entity.setStatusDescription(DescriptionUtils.limit(limitReachedDescription(description, nextRetryCount)));
+            entity.setNextAttemptDate(now);
+            clearLease(entity);
+            return;
+        }
+
+        entity.setStatus(IdempotencyStatus.RESERVED);
+        entity.setStatusDescription(DescriptionUtils.limit(description));
+        entity.setNextAttemptDate(now.plus(delay));
+        clearLease(entity);
+    }
+
+    private void applyRestart(IdempotencyEntity entity) {
+        entity.setStatus(IdempotencyStatus.RESERVED);
+        entity.setStatusDescription(null);
+        entity.setRetryCount(0);
+        entity.setNextAttemptDate(OffsetDateTime.now(ZoneOffset.UTC));
+        clearLease(entity);
+    }
+
+    private void clearLease(IdempotencyEntity entity) {
+        entity.setOwnerId(null);
+        entity.setLeaseUntil(null);
+    }
+
+    private String limitReachedDescription(String description, int attempts) {
+        String baseDescription = description == null || description.isBlank() ? "Повторная попытка не удалась." : description;
+        return baseDescription + " Достигнут лимит повторных попыток: " + attempts;
     }
 }

--- a/core-service/src/main/java/ru/itmo/idempotency/core/service/KafkaEventOutboxSearchService.java
+++ b/core-service/src/main/java/ru/itmo/idempotency/core/service/KafkaEventOutboxSearchService.java
@@ -17,6 +17,6 @@ public class KafkaEventOutboxSearchService {
 
     @Transactional
     public Optional<KafkaEventOutboxEntity> acquireFirstNotLocked() {
-        return kafkaEventOutboxRepository.lockFirstByStatus(OutboxStatus.NEW.name());
+        return kafkaEventOutboxRepository.lockFirstAvailableByStatus(OutboxStatus.NEW.name());
     }
 }

--- a/core-service/src/main/java/ru/itmo/idempotency/core/service/KafkaEventOutboxService.java
+++ b/core-service/src/main/java/ru/itmo/idempotency/core/service/KafkaEventOutboxService.java
@@ -10,6 +10,11 @@ import ru.itmo.idempotency.core.domain.OutboxStatus;
 import ru.itmo.idempotency.core.domain.ProcessingResult;
 import ru.itmo.idempotency.core.repository.KafkaEventOutboxRepository;
 
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class KafkaEventOutboxService {
@@ -22,6 +27,7 @@ public class KafkaEventOutboxService {
                                        RouteModels.RouteSnapshot snapshot,
                                        ProcessingResult result,
                                        String resultDescription) {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
         return kafkaEventOutboxRepository.save(KafkaEventOutboxEntity.builder()
                 .globalKey(globalKey)
                 .serviceName(snapshot.service())
@@ -30,18 +36,112 @@ public class KafkaEventOutboxService {
                 .status(OutboxStatus.NEW)
                 .result(result)
                 .resultDescription(DescriptionUtils.limit(resultDescription))
+                .retryCount(0)
+                .nextAttemptDate(now)
                 .build());
     }
 
     @Transactional
+    public Optional<KafkaEventOutboxEntity> claimNextNew(String ownerId, Duration leaseDuration) {
+        return kafkaEventOutboxRepository.lockFirstAvailableByStatus(OutboxStatus.NEW.name())
+                .map(entity -> claim(entity, ownerId, leaseDuration));
+    }
+
+    @Transactional
     public KafkaEventOutboxEntity changeStatus(KafkaEventOutboxEntity entity, OutboxStatus status, String description) {
-        entity.setStatus(status);
-        entity.setStatusDescription(DescriptionUtils.limit(description));
+        applyStatus(entity, status, description);
         return kafkaEventOutboxRepository.save(entity);
     }
 
     @Transactional
     public KafkaEventOutboxEntity markAsError(KafkaEventOutboxEntity entity, String description) {
         return changeStatus(entity, OutboxStatus.ERROR, description);
+    }
+
+    @Transactional
+    public KafkaEventOutboxEntity scheduleRetry(KafkaEventOutboxEntity entity,
+                                                String description,
+                                                Duration delay,
+                                                int maxAttempts) {
+        applyRetry(entity, description, delay, maxAttempts);
+        return kafkaEventOutboxRepository.save(entity);
+    }
+
+    @Transactional
+    public boolean completeClaimedDispatch(Long id, String ownerId, String description) {
+        return updateClaimed(id, ownerId, entity -> applyStatus(entity, OutboxStatus.DONE, description));
+    }
+
+    @Transactional
+    public boolean retryClaimedDispatch(Long id,
+                                        String ownerId,
+                                        String description,
+                                        Duration delay,
+                                        int maxAttempts) {
+        return updateClaimed(id, ownerId, entity -> applyRetry(entity, description, delay, maxAttempts));
+    }
+
+    @Transactional
+    public boolean failClaimedDispatch(Long id, String ownerId, String description) {
+        return updateClaimed(id, ownerId, entity -> applyStatus(entity, OutboxStatus.ERROR, description));
+    }
+
+    private KafkaEventOutboxEntity claim(KafkaEventOutboxEntity entity, String ownerId, Duration leaseDuration) {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        entity.setOwnerId(ownerId);
+        entity.setLeaseUntil(now.plus(leaseDuration));
+        entity.setLastClaimDate(now);
+        return kafkaEventOutboxRepository.save(entity);
+    }
+
+    private boolean updateClaimed(Long id,
+                                  String ownerId,
+                                  java.util.function.Consumer<KafkaEventOutboxEntity> updater) {
+        KafkaEventOutboxEntity entity = kafkaEventOutboxRepository.findByIdForUpdate(id).orElse(null);
+        if (entity == null || entity.getOwnerId() == null || !entity.getOwnerId().equals(ownerId)) {
+            return false;
+        }
+
+        updater.accept(entity);
+        kafkaEventOutboxRepository.save(entity);
+        return true;
+    }
+
+    private void applyStatus(KafkaEventOutboxEntity entity, OutboxStatus status, String description) {
+        entity.setStatus(status);
+        entity.setStatusDescription(DescriptionUtils.limit(description));
+        entity.setNextAttemptDate(OffsetDateTime.now(ZoneOffset.UTC));
+        clearLease(entity);
+    }
+
+    private void applyRetry(KafkaEventOutboxEntity entity,
+                            String description,
+                            Duration delay,
+                            int maxAttempts) {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        int nextRetryCount = entity.getRetryCount() + 1;
+        entity.setRetryCount(nextRetryCount);
+        if (nextRetryCount >= maxAttempts) {
+            entity.setStatus(OutboxStatus.ERROR);
+            entity.setStatusDescription(DescriptionUtils.limit(limitReachedDescription(description, nextRetryCount)));
+            entity.setNextAttemptDate(now);
+            clearLease(entity);
+            return;
+        }
+
+        entity.setStatus(OutboxStatus.NEW);
+        entity.setStatusDescription(DescriptionUtils.limit(description));
+        entity.setNextAttemptDate(now.plus(delay));
+        clearLease(entity);
+    }
+
+    private void clearLease(KafkaEventOutboxEntity entity) {
+        entity.setOwnerId(null);
+        entity.setLeaseUntil(null);
+    }
+
+    private String limitReachedDescription(String description, int attempts) {
+        String baseDescription = description == null || description.isBlank() ? "Повторная попытка не удалась." : description;
+        return baseDescription + " Достигнут лимит повторных попыток: " + attempts;
     }
 }

--- a/core-service/src/main/java/ru/itmo/idempotency/core/service/KafkaExceptionClassifier.java
+++ b/core-service/src/main/java/ru/itmo/idempotency/core/service/KafkaExceptionClassifier.java
@@ -1,0 +1,22 @@
+package ru.itmo.idempotency.core.service;
+
+import org.apache.kafka.common.errors.RetriableException;
+
+import java.util.concurrent.TimeoutException;
+
+public final class KafkaExceptionClassifier {
+
+    private KafkaExceptionClassifier() {
+    }
+
+    public static boolean isRetriable(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof RetriableException || current instanceof TimeoutException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}

--- a/core-service/src/main/resources/db/migration/V2__distributed_retry_and_scaling.sql
+++ b/core-service/src/main/resources/db/migration/V2__distributed_retry_and_scaling.sql
@@ -1,0 +1,17 @@
+ALTER TABLE idempotency
+    ADD COLUMN IF NOT EXISTS retry_count INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE idempotency
+    ADD COLUMN IF NOT EXISTS next_attempt_date TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS idx_idempotency_status_next_attempt_date
+    ON idempotency (status, next_attempt_date, create_date);
+
+ALTER TABLE kafka_event_outbox
+    ADD COLUMN IF NOT EXISTS retry_count INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE kafka_event_outbox
+    ADD COLUMN IF NOT EXISTS next_attempt_date TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS idx_kafka_event_outbox_status_next_attempt_date
+    ON kafka_event_outbox (status, next_attempt_date, create_date);

--- a/core-service/src/main/resources/db/migration/V3__leases_and_claiming.sql
+++ b/core-service/src/main/resources/db/migration/V3__leases_and_claiming.sql
@@ -1,0 +1,31 @@
+ALTER TABLE idempotency
+    ADD COLUMN IF NOT EXISTS owner_id VARCHAR(128);
+
+ALTER TABLE idempotency
+    ADD COLUMN IF NOT EXISTS lease_until TIMESTAMPTZ;
+
+ALTER TABLE idempotency
+    ADD COLUMN IF NOT EXISTS last_claim_date TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_idempotency_status_claim_window
+    ON idempotency (status, next_attempt_date, lease_until, create_date);
+
+CREATE INDEX IF NOT EXISTS idx_idempotency_expired_leases
+    ON idempotency (lease_until)
+    WHERE owner_id IS NOT NULL;
+
+ALTER TABLE kafka_event_outbox
+    ADD COLUMN IF NOT EXISTS owner_id VARCHAR(128);
+
+ALTER TABLE kafka_event_outbox
+    ADD COLUMN IF NOT EXISTS lease_until TIMESTAMPTZ;
+
+ALTER TABLE kafka_event_outbox
+    ADD COLUMN IF NOT EXISTS last_claim_date TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_kafka_event_outbox_claim_window
+    ON kafka_event_outbox (status, next_attempt_date, lease_until, create_date);
+
+CREATE INDEX IF NOT EXISTS idx_kafka_event_outbox_expired_leases
+    ON kafka_event_outbox (lease_until)
+    WHERE owner_id IS NOT NULL;

--- a/core-service/src/test/java/ru/itmo/idempotency/core/CoreAssignedIdPersistenceIntegrationTest.java
+++ b/core-service/src/test/java/ru/itmo/idempotency/core/CoreAssignedIdPersistenceIntegrationTest.java
@@ -1,0 +1,108 @@
+package ru.itmo.idempotency.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import ru.itmo.idempotency.core.domain.IdempotencyEntity;
+import ru.itmo.idempotency.core.domain.IdempotencyStatus;
+import ru.itmo.idempotency.core.repository.IdempotencyRepository;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.springframework.kafka.test.EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@EmbeddedKafka(partitions = 1)
+class CoreAssignedIdPersistenceIntegrationTest {
+
+    @Autowired
+    private IdempotencyRepository idempotencyRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", () -> "jdbc:h2:mem:core-assigned-id-persistence;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;INIT=CREATE DOMAIN IF NOT EXISTS JSONB AS JSON\\;CREATE DOMAIN IF NOT EXISTS TIMESTAMPTZ AS TIMESTAMP WITH TIME ZONE");
+        registry.add("spring.datasource.username", () -> "sa");
+        registry.add("spring.datasource.password", () -> "");
+        registry.add("spring.flyway.enabled", () -> "false");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        registry.add("app.routes-file", () -> createRoutesFile(System.getProperty(SPRING_EMBEDDED_KAFKA_BROKERS)));
+    }
+
+    @AfterEach
+    void tearDown() {
+        idempotencyRepository.deleteAll();
+    }
+
+    @Test
+    void shouldTreatAssignedIdEntityAsNewOnFirstSave() throws Exception {
+        IdempotencyEntity entity = IdempotencyEntity.builder()
+                .globalKey("sender-service:system1-to-system2:assigned-id-1")
+                .sourceUid("assigned-id-1")
+                .serviceName("sender-service")
+                .integrationName("system1-to-system2")
+                .yamlSnapshot(objectMapper.readTree("{}"))
+                .headers(objectMapper.readTree("{}"))
+                .payload(objectMapper.readTree("{}"))
+                .status(IdempotencyStatus.RESERVED)
+                .build();
+
+        Assertions.assertTrue(entity.isNew());
+
+        IdempotencyEntity saved = idempotencyRepository.saveAndFlush(entity);
+
+        Assertions.assertNotNull(saved.getCreateDate());
+        Assertions.assertNotNull(saved.getUpdateDate());
+        Assertions.assertNotNull(entity.getCreateDate());
+        Assertions.assertNotNull(entity.getUpdateDate());
+        Assertions.assertFalse(saved.isNew());
+        Assertions.assertFalse(entity.isNew());
+    }
+
+    private static String createRoutesFile(String bootstrapServers) {
+        try {
+            Path file = Files.createTempFile("routes-assigned-id-test-", ".yaml");
+            Files.writeString(file, """
+                    service:
+                      name: sender-service
+
+                    kafka:
+                      routes:
+                        system1-to-system2:
+                          sender:
+                            producer:
+                              host: %s
+                              topic: sender.events.inbound
+                            consumer:
+                              host: %s
+                              topic: sender.events.request-out
+                              group: sender-test-replies
+                          receiver:
+                            producer:
+                              host: %s
+                              topic: receiver.events.unique
+                            consumer:
+                              host: %s
+                              topic: receiver.events.reply
+                              group: core-test-replies
+                          idempotency:
+                            enabled: true
+                    """.formatted(bootstrapServers, bootstrapServers, bootstrapServers, bootstrapServers));
+            return file.toAbsolutePath().toString();
+        } catch (IOException exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+}

--- a/core-service/src/test/java/ru/itmo/idempotency/core/CoreLeaseClaimingIntegrationTest.java
+++ b/core-service/src/test/java/ru/itmo/idempotency/core/CoreLeaseClaimingIntegrationTest.java
@@ -1,0 +1,166 @@
+package ru.itmo.idempotency.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import ru.itmo.idempotency.core.domain.IdempotencyEntity;
+import ru.itmo.idempotency.core.domain.IdempotencyStatus;
+import ru.itmo.idempotency.core.domain.KafkaEventOutboxEntity;
+import ru.itmo.idempotency.core.domain.OutboxStatus;
+import ru.itmo.idempotency.core.domain.ProcessingResult;
+import ru.itmo.idempotency.core.repository.IdempotencyRepository;
+import ru.itmo.idempotency.core.repository.KafkaEventOutboxRepository;
+import ru.itmo.idempotency.core.service.IdempotencyService;
+import ru.itmo.idempotency.core.service.KafkaEventOutboxService;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.springframework.kafka.test.EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@EmbeddedKafka(partitions = 1)
+class CoreLeaseClaimingIntegrationTest {
+
+    @Autowired
+    private IdempotencyService idempotencyService;
+
+    @Autowired
+    private KafkaEventOutboxService kafkaEventOutboxService;
+
+    @Autowired
+    private IdempotencyRepository idempotencyRepository;
+
+    @Autowired
+    private KafkaEventOutboxRepository kafkaEventOutboxRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", () -> "jdbc:h2:mem:core-lease-claiming;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;INIT=CREATE DOMAIN IF NOT EXISTS JSONB AS JSON\\;CREATE DOMAIN IF NOT EXISTS TIMESTAMPTZ AS TIMESTAMP WITH TIME ZONE");
+        registry.add("spring.datasource.username", () -> "sa");
+        registry.add("spring.datasource.password", () -> "");
+        registry.add("spring.flyway.enabled", () -> "false");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        registry.add("app.routes-file", () -> createRoutesFile(System.getProperty(SPRING_EMBEDDED_KAFKA_BROKERS)));
+    }
+
+    @AfterEach
+    void tearDown() {
+        kafkaEventOutboxRepository.deleteAll();
+        idempotencyRepository.deleteAll();
+    }
+
+    @Test
+    void shouldReclaimExpiredDeliveryLeaseAndRejectPreviousOwnerCompletion() throws Exception {
+        String globalKey = "sender-service:system1-to-system2:lease-1";
+        idempotencyRepository.saveAndFlush(IdempotencyEntity.builder()
+                .globalKey(globalKey)
+                .sourceUid("lease-1")
+                .serviceName("sender-service")
+                .integrationName("system1-to-system2")
+                .yamlSnapshot(objectMapper.readTree("{}"))
+                .headers(objectMapper.readTree("{}"))
+                .payload(objectMapper.readTree("{}"))
+                .status(IdempotencyStatus.RESERVED)
+                .retryCount(0)
+                .nextAttemptDate(OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(1))
+                .build());
+
+        Assertions.assertTrue(idempotencyService.claimNextReserved("worker-a", Duration.ofSeconds(30)).isPresent());
+        Assertions.assertTrue(idempotencyService.claimNextReserved("worker-b", Duration.ofSeconds(30)).isEmpty());
+
+        IdempotencyEntity entity = idempotencyRepository.findById(globalKey).orElseThrow();
+        entity.setLeaseUntil(OffsetDateTime.now(ZoneOffset.UTC).minusSeconds(1));
+        idempotencyRepository.saveAndFlush(entity);
+
+        Assertions.assertTrue(idempotencyService.claimNextReserved("worker-b", Duration.ofSeconds(30)).isPresent());
+        Assertions.assertFalse(idempotencyService.completeClaimedDelivery(globalKey, "worker-a", IdempotencyStatus.COMMITTED, null));
+        Assertions.assertTrue(idempotencyService.completeClaimedDelivery(globalKey, "worker-b", IdempotencyStatus.COMMITTED, null));
+
+        IdempotencyEntity completed = idempotencyRepository.findById(globalKey).orElseThrow();
+        Assertions.assertEquals(IdempotencyStatus.COMMITTED, completed.getStatus());
+        Assertions.assertNull(completed.getOwnerId());
+        Assertions.assertNull(completed.getLeaseUntil());
+    }
+
+    @Test
+    void shouldReclaimExpiredOutboxLeaseAndRejectPreviousOwnerCompletion() throws Exception {
+        KafkaEventOutboxEntity outboxEntity = kafkaEventOutboxRepository.saveAndFlush(KafkaEventOutboxEntity.builder()
+                .globalKey("sender-service:system1-to-system2:lease-outbox")
+                .serviceName("sender-service")
+                .integrationName("system1-to-system2")
+                .yamlSnapshot(objectMapper.readTree("{}"))
+                .status(OutboxStatus.NEW)
+                .result(ProcessingResult.SUCCESS)
+                .resultDescription("ok")
+                .retryCount(0)
+                .nextAttemptDate(OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(1))
+                .build());
+
+        Assertions.assertTrue(kafkaEventOutboxService.claimNextNew("worker-a", Duration.ofSeconds(30)).isPresent());
+        Assertions.assertTrue(kafkaEventOutboxService.claimNextNew("worker-b", Duration.ofSeconds(30)).isEmpty());
+
+        KafkaEventOutboxEntity stored = kafkaEventOutboxRepository.findById(outboxEntity.getId()).orElseThrow();
+        stored.setLeaseUntil(OffsetDateTime.now(ZoneOffset.UTC).minusSeconds(1));
+        kafkaEventOutboxRepository.saveAndFlush(stored);
+
+        Assertions.assertTrue(kafkaEventOutboxService.claimNextNew("worker-b", Duration.ofSeconds(30)).isPresent());
+        Assertions.assertFalse(kafkaEventOutboxService.completeClaimedDispatch(outboxEntity.getId(), "worker-a", null));
+        Assertions.assertTrue(kafkaEventOutboxService.completeClaimedDispatch(outboxEntity.getId(), "worker-b", null));
+
+        KafkaEventOutboxEntity completed = kafkaEventOutboxRepository.findById(outboxEntity.getId()).orElseThrow();
+        Assertions.assertEquals(OutboxStatus.DONE, completed.getStatus());
+        Assertions.assertNull(completed.getOwnerId());
+        Assertions.assertNull(completed.getLeaseUntil());
+    }
+
+    private static String createRoutesFile(String bootstrapServers) {
+        try {
+            Path file = Files.createTempFile("routes-lease-test-", ".yaml");
+            Files.writeString(file, """
+                    service:
+                      name: sender-service
+
+                    kafka:
+                      routes:
+                        system1-to-system2:
+                          sender:
+                            producer:
+                              host: %s
+                              topic: sender.events.inbound
+                            consumer:
+                              host: %s
+                              topic: sender.events.request-out
+                              group: sender-test-replies
+                          receiver:
+                            producer:
+                              host: %s
+                              topic: receiver.events.unique
+                            consumer:
+                              host: %s
+                              topic: receiver.events.reply
+                              group: core-test-replies
+                          idempotency:
+                            enabled: true
+                    """.formatted(bootstrapServers, bootstrapServers, bootstrapServers, bootstrapServers));
+            return file.toAbsolutePath().toString();
+        } catch (IOException exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+}


### PR DESCRIPTION
- добавить миграции для retry_count, next_attempt_date, owner_id, lease_until, last_claim_date
- обновить сущности IdempotencyEntity и KafkaEventOutboxEntity
- доработать repositories для lease-aware поиска и claim window
- обновить IdempotencyService и KafkaEventOutboxService под claim/retry/fail/complete модель
- добавить классификацию retriable Kafka ошибок
- обеспечить корректное сохранение IdempotencyEntity с assigned globalKey
- покрыть claiming и assigned-id persistence интеграционными тестами